### PR TITLE
Restore old LD wrapper behavior

### DIFF
--- a/packages/applications/databases/postgresql/default/client/.hab-plan-config.toml
+++ b/packages/applications/databases/postgresql/default/client/.hab-plan-config.toml
@@ -2,4 +2,4 @@
 license-not-found = {level = "off", source-shasum = "aeb7a196be3ebed1a7476ef565f39722187c108dd47da7489be9c4fcae982ace"}
 missing-license = {level = "off", source-shasum = "aeb7a196be3ebed1a7476ef565f39722187c108dd47da7489be9c4fcae982ace"}
 unused-dependency = {ignored_packages = ["core/{libxml2,geos,proj,bash,gdal,perl,libossp-uuid}"]}
-unused-runpath-entry = {ignored_files = ["bin/*"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/applications/databases/sqlite/.hab-plan-config.toml
+++ b/packages/applications/databases/sqlite/.hab-plan-config.toml
@@ -1,2 +1,3 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373e39869c"}
+unused-runpath-entry = {level = "off"}

--- a/packages/applications/editors/vim/.hab-plan-config.toml
+++ b/packages/applications/editors/vim/.hab-plan-config.toml
@@ -4,3 +4,4 @@ host-script-interpreter = {ignored_files = ["share/*"]}
 license-not-found = {level = "off", source-shasum = "c75acdac8b80e664666663d3429efe1eb25be7f13db0bd3697a2d2a78dd1bb66"}
 missing-license = {level = "off", source-shasum = "c75acdac8b80e664666663d3429efe1eb25be7f13db0bd3697a2d2a78dd1bb66"}
 missing-script-interpreter-dependency = {level = "off", ignored_files = ["share/*"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/applications/servers/nginx/.hab-plan-config.toml
+++ b/packages/applications/servers/nginx/.hab-plan-config.toml
@@ -1,2 +1,3 @@
 [rules]
 unused-dependency = {ignored_packages = ["core/{libedit,ncurses,bzip2}"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/applications/version-management/git/.hab-plan-config.toml
+++ b/packages/applications/version-management/git/.hab-plan-config.toml
@@ -7,3 +7,4 @@ license-not-found = {level = "off", source-shasum = "02047f8dc8934d57ff5e02aadd8
 missing-license = {level = "off", source-shasum = "02047f8dc8934d57ff5e02aadd8a2fe8e0bcf94a7158da375e48086cc46fce1d"}
 # These packages are needed are runtime
 unused-dependency = {ignored_packages = ["core/{gettext,sed,cacerts,openssh}"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-support/hab-cc-wrapper/plan.sh
+++ b/packages/bootstrap/build-support/hab-cc-wrapper/plan.sh
@@ -1,5 +1,5 @@
 # shellcheck disable=2154
-commit_hash="dbf96b1bf6711d053864a406634d5be5c620a44d"
+commit_hash="5d4f4bc90870dc0bcabe509badb0350ba0ee920b"
 native_target="${TARGET_ARCH:-${pkg_target%%-*}}-hab-linux-gnu"
 
 pkg_name="hab-cc-wrapper"
@@ -8,7 +8,7 @@ pkg_version="1.0.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/habitat-sh/hab-pkg-wrappers/archive/${commit_hash}.tar.gz"
-pkg_shasum="c62127bdd4e60916c5556b8be2ee0f10a54450ebda6cd30e71a1add59b78a59b"
+pkg_shasum="4a59ae8c5dba6fff24937b38dde80d01e516afbe6c094f31d6c61d6265e44441"
 pkg_dirname="hab-pkg-wrappers-${commit_hash}"
 pkg_build_deps=(
 	core/native-rust

--- a/packages/bootstrap/build-support/hab-ld-wrapper/plan.sh
+++ b/packages/bootstrap/build-support/hab-ld-wrapper/plan.sh
@@ -1,5 +1,5 @@
 # shellcheck disable=2154
-commit_hash="dbf96b1bf6711d053864a406634d5be5c620a44d"
+commit_hash="5d4f4bc90870dc0bcabe509badb0350ba0ee920b"
 native_target="${TARGET_ARCH:-${pkg_target%%-*}}-hab-linux-gnu"
 
 pkg_name="hab-ld-wrapper"
@@ -8,7 +8,7 @@ pkg_version="1.0.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_source="https://github.com/habitat-sh/hab-pkg-wrappers/archive/${commit_hash}.tar.gz"
-pkg_shasum="c62127bdd4e60916c5556b8be2ee0f10a54450ebda6cd30e71a1add59b78a59b"
+pkg_shasum="4a59ae8c5dba6fff24937b38dde80d01e516afbe6c094f31d6c61d6265e44441"
 pkg_dirname="hab-pkg-wrappers-${commit_hash}"
 pkg_build_deps=(
 	core/native-rust

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-binutils/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-binutils/.hab-plan-config.toml
@@ -5,3 +5,4 @@ license-not-found = {level = "off", source-shasum = "67fc1a4030d08ee877a4867d3dc
 missing-license = {level = "off", source-shasum = "67fc1a4030d08ee877a4867d3dcab35828148f87e1fd05da6db585ed5a166bd4"}
 # The hab-ld-wrapper binary is used at runtime to process arguments
 unused-dependency = {ignored_packages = ["core/hab-ld-wrapper"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-gcc/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-gcc/.hab-plan-config.toml
@@ -5,3 +5,4 @@ license-not-found = {level = "off", source-shasum = "c95da32f440378d7751dd955331
 missing-license = {level = "off", source-shasum = "c95da32f440378d7751dd95533186f7fc05ceb4fb65eb5b85234e6299eb9838e"}
 # GCC uses binutils at runtime for linking
 unused-dependency = {ignored_packages = ["core/build-tools-binutils", "core/hab-cc-wrapper"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-glibc/plan.sh
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-glibc/plan.sh
@@ -59,8 +59,16 @@ do_prepare() {
 
 	patch -p1 <"$PLAN_CONTEXT/dont-use-system-ld-so-cache.patch"
 
+	# 'HAB_LD_LINK_MODE' is used to control the way the habitat linker wrapper adds rpath entries.
+	# By setting it to 'minimal', we instruct the linker wrapper to add an rpath entry only if a library
+	# is going to be linked into the resulting binary or library.
+	# This setting is crucial when dealing with certain glibc ELF binaries/libraries. These are expected
+	# not to have a DT_RUNPATH entry, and using the 'minimal' mode ensures this expectation is met.
+	export HAB_LD_LINK_MODE="minimal"
+
 	build_line "Setting PATH=${PATH}"
 	build_line "Setting CPPFLAGS=${CPPFLAGS}"
+	build_line "Setting HAB_LD_LINK_MODE=${HAB_LD_LINK_MODE}"
 }
 
 do_build() {

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-gmp/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-gmp/.hab-plan-config.toml
@@ -3,3 +3,4 @@ docker-image = "hab-bootstrap:20230523"
 [rules]
 license-not-found = {level = "off", source-shasum = "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2"}
 missing-license = {level = "off", source-shasum = "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-isl/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-isl/.hab-plan-config.toml
@@ -1,1 +1,4 @@
 docker-image = "hab-bootstrap:20230523"
+
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-libmpc/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-libmpc/.hab-plan-config.toml
@@ -2,3 +2,4 @@ docker-image = "hab-bootstrap:20230523"
 
 [rules]
 license-not-found = {level = "off", source-shasum = "17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-libstdcxx/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-libstdcxx/.hab-plan-config.toml
@@ -9,3 +9,4 @@ missing-license = {level = "off", source-shasum = "c95da32f440378d7751dd95533186
 unused-dependency = {level = "warn", ignored_packages = [
     "core/build-tools-linux-headers"
 ]}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-mpfr/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-mpfr/.hab-plan-config.toml
@@ -3,3 +3,4 @@ docker-image = "hab-bootstrap:20230523"
 [rules]
 license-not-found = {level = "off", source-shasum = "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"}
 missing-license = {level = "off", source-shasum = "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-ncurses/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-ncurses/.hab-plan-config.toml
@@ -3,3 +3,4 @@ docker-image = "hab-bootstrap:20230523"
 [rules]
 license-not-found = {level = "off", source-shasum = "30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d"}
 missing-license = {level = "off", source-shasum = "30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-openssl/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-openssl/.hab-plan-config.toml
@@ -2,3 +2,4 @@ docker-image = "hab-bootstrap:20230523"
 
 [rules]
 missing-license = {level = "off", source-shasum = '83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e'}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-xz/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-xz/.hab-plan-config.toml
@@ -3,3 +3,4 @@ docker-image = "hab-bootstrap:20230523"
 [rules]
 license-not-found = {level = "off", source-shasum = "f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"}
 missing-license = {level = "off", source-shasum = "f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/target-tools/build-tools-bison/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/target-tools/build-tools-bison/.hab-plan-config.toml
@@ -6,3 +6,4 @@ unused-dependency = {ignored_packages = [
     "core/build-tools-m4",
     "core/build-tools-gettext"
 ]}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/target-tools/build-tools-gettext/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/target-tools/build-tools-gettext/.hab-plan-config.toml
@@ -14,3 +14,4 @@ unused-dependency = {ignored_packages = [
     "core/build-tools-sed",
     "core/build-tools-xz"
 ]}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/target-tools/build-tools-perl/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/target-tools/build-tools-perl/.hab-plan-config.toml
@@ -6,3 +6,4 @@ missing-license = {level = "off", source-shasum = "551efc818b968b05216024fb0b727
 script-interpreter-not-found = {ignored_files = [
     "lib/perl5/5.34/core_perl/*"
 ]}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/target-tools/build-tools-python/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/target-tools/build-tools-python/.hab-plan-config.toml
@@ -5,3 +5,4 @@ env-script-interpreter-not-found = {ignored_files = ["lib/python3.10/lib2to3/*"]
 # Ignore bash usage in test scripts
 host-script-interpreter = {ignored_files = ["lib/python3.10/test/*"]}
 missing-license = {level = "off", source-shasum = "c4e0cbad57c90690cb813fb4663ef670b4d0f587d8171e2c42bd4c9245bd2758"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/target-tools/build-tools-texinfo/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/target-tools/build-tools-texinfo/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "8eb753ed28bca21f8f56c1a180362aed789229bd62fff58bf8368e9beb59fec4"}
 missing-license = {level = "off", source-shasum = "8eb753ed28bca21f8f56c1a180362aed789229bd62fff58bf8368e9beb59fec4"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/build-tools/target-tools/build-tools-util-linux/.hab-plan-config.toml
+++ b/packages/bootstrap/build-tools/target-tools/build-tools-util-linux/.hab-plan-config.toml
@@ -3,3 +3,4 @@
 host-script-interpreter = {ignored_files = ["*-example.{bash,tcsh}"]}
 license-not-found = {level = "off", source-shasum = "bd07b7e98839e0359842110525a3032fdb8eaf3a90bedde3dd1652d32d15cce5"}
 missing-license = {level = "off", source-shasum = "bd07b7e98839e0359842110525a3032fdb8eaf3a90bedde3dd1652d32d15cce5"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/stage0/binutils/.hab-plan-config.toml
+++ b/packages/bootstrap/stage0/binutils/.hab-plan-config.toml
@@ -4,3 +4,4 @@ missing-license = {level = "off", source-shasum = "67fc1a4030d08ee877a4867d3dcab
 # The hab-ld-wrapper binary is used at runtime to process arguments
 # Bash is needed as a runtime interpreter for the ld-wrapper.sh script
 unused-dependency = {ignored_packages = ["core/hab-ld-wrapper", "core/build-tools-bash-static"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/stage0/bzip2/.hab-plan-config.toml
+++ b/packages/bootstrap/stage0/bzip2/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/stage0/flex/.hab-plan-config.toml
+++ b/packages/bootstrap/stage0/flex/.hab-plan-config.toml
@@ -1,2 +1,3 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/stage0/glibc/plan.sh
+++ b/packages/bootstrap/stage0/glibc/plan.sh
@@ -68,10 +68,18 @@ do_prepare() {
 	# of glibc. Thanks to https://github.com/NixOS/nixpkgs/pull/137601 for the solution.
 	patch -p1 <"$PLAN_CONTEXT/hab-nss-open-files.patch"
 
+	# 'HAB_LD_LINK_MODE' is used to control the way the habitat linker wrapper adds rpath entries.
+	# By setting it to '', we instruct the linker wrapper to add an rpath entry only if a library
+	# is going to be linked into the resulting binary or library.
+	# This setting is crucial when dealing with certain glibc ELF binaries/libraries. These are expected
+	# not to have a DT_RUNPATH entry, and using the '' mode ensures this expectation is met.
+	export HAB_LD_LINK_MODE="minimal"
+
 	build_line "Unsetting LDFLAGS"
 	build_line "Unsetting CFLAGS"
 	build_line "Unsetting CXXFLAGS"
 	build_line "Unsetting CPPFLAGS"
+	build_line "Setting HAB_LD_LINK_MODE=${HAB_LD_LINK_MODE}"
 }
 
 do_build() {

--- a/packages/bootstrap/stage0/xz/.hab-plan-config.toml
+++ b/packages/bootstrap/stage0/xz/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"}
 missing-license = {level = "off", source-shasum = "f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/stage1/flex/.hab-plan-config.toml
+++ b/packages/bootstrap/stage1/flex/.hab-plan-config.toml
@@ -1,2 +1,3 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995"}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/stage1/gcc/.hab-plan-config.toml
+++ b/packages/bootstrap/stage1/gcc/.hab-plan-config.toml
@@ -6,9 +6,4 @@ unused-dependency = {ignored_packages = [
     "core/binutils-stage0",
     "core/hab-cc-wrapper"
 ]}
-# The build system specifically adds rpaths entries for $pkg_prefix/lib and $pkg_prefix/lib64 folders.
-# TODO: Find out why they are needed, though we still cannot remove them using our hab-ld-wrapper.
-unused-runpath-entry = {ignored_files = [
-    "lib64/lib{atomic,cc1,itm,ssp,gomp,stdc++,quadmath}.so*",
-    "lib/gcc/*/*/plugin/lib{cp1,cc1}plugin.so*"
-]}
+unused-runpath-entry = {level = "off"}

--- a/packages/bootstrap/stage1/tcl/.hab-plan-config.toml
+++ b/packages/bootstrap/stage1/tcl/.hab-plan-config.toml
@@ -2,5 +2,4 @@
 missing-license = {level = "off", source-shasum = '8c0486668586672c5693d7d95817cb05a18c5ecca2f40e2836b9578064088258'}
 # TZ data is used at runtime
 unused-dependency = {ignored_packages = ["core/tzdata"]}
-# The build system adds a rpath for the $pkg_prefix/lib folder,
-unused-runpath-entry = {ignored_files = ["lib/libtcl*.so"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/compilers/gcc/9/base/.hab-plan-config.toml
+++ b/packages/development/compilers/gcc/9/base/.hab-plan-config.toml
@@ -5,9 +5,4 @@ missing-license = {level = "off", source-shasum = "c95da32f440378d7751dd95533186
 unused-dependency = {ignored_packages = [
     "core/hab-cc-wrapper"
 ]}
-# The build system specifically adds rpaths entries for $pkg_prefix/lib and $pkg_prefix/lib64 folders.
-# TODO: Find out why they are needed, though we still cannot remove them using our hab-ld-wrapper.
-unused-runpath-entry = {ignored_files = [
-    "lib64/lib{atomic,cc1,itm,ssp,gomp,stdc++,quadmath}.so*",
-    "lib/gcc/*/*/plugin/lib{cp1,cc1}plugin.so*"
-]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/compilers/gcc/9/meta/plan.sh
+++ b/packages/development/compilers/gcc/9/meta/plan.sh
@@ -23,7 +23,7 @@ pkg_deps=(
 
 do_prepare() {
 	# Set gcc to use the newly built binutils
-	set_runtime_env "HAB_GCC_LD_BIN" "$(pkg_path_for binutils-base)/bin"
+	set_runtime_env "HAB_GCC_LD_BIN" "$(pkg_path_for binutils)/bin"
 }
 
 do_build() {

--- a/packages/development/interpreters/erlang/default/.hab-plan-config.toml
+++ b/packages/development/interpreters/erlang/default/.hab-plan-config.toml
@@ -4,3 +4,4 @@ missing-license = {level = "off", source-shasum = "2a2a6538c25736bda659af647ea2a
 # sed and gawk are used by scripts at runtime
 # - lib/erlang/erts-<version>/bin/start_erl.src
 unused-dependency = {ignored_packages = ["core/{sed,gawk}"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/interpreters/node/default/.hab-plan-config.toml
+++ b/packages/development/interpreters/node/default/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "89d22d34fd4ba3715252dcd2dd94d1699338436463b277163ed950040c7b621a"}
 missing-license = {level = "off", source-shasum = "89d22d34fd4ba3715252dcd2dd94d1699338436463b277163ed950040c7b621a"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/interpreters/perl/.hab-plan-config.toml
+++ b/packages/development/interpreters/perl/.hab-plan-config.toml
@@ -10,4 +10,4 @@ unused-dependency = {ignored_packages = ["core/{coreutils,less}"]}
 # folder. However when the install is done, the final libperl.so is installed in the rpath
 # specified by the build system: lib/perl5/5.34.0/aarch64-linux-thread-multi/CORE.
 # Hence the 'lib' folder becomes an unused runpath entry.
-unused-runpath-entry = {ignored_files = ["bin/perl*"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/interpreters/python/2/.hab-plan-config.toml
+++ b/packages/development/interpreters/python/2/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814"}
 missing-license = {level = "off", source-shasum = "da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/interpreters/ruby/30/ruby30/.hab-plan-config.toml
+++ b/packages/development/interpreters/ruby/30/ruby30/.hab-plan-config.toml
@@ -7,3 +7,4 @@ script-interpreter-not-found = {ignored_files = ["lib/ruby/*/bundler/templates/*
 # core/nss-myhostname: This is apparently required at runtime, for some DNS lookup behaviour?
 # https://github.com/habitat-sh/core-plans/commit/7761ccef724292640d14143ccb0cd5466e877fa5
 unused-dependency = {ignored_packages = ["core/{nss-myhostname,ncurses}"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/interpreters/ruby/31/ruby31/.hab-plan-config.toml
+++ b/packages/development/interpreters/ruby/31/ruby31/.hab-plan-config.toml
@@ -10,3 +10,4 @@ missing-license = {level = "off", source-shasum = "61843112389f02b735428b53bb64c
 # core/nss-myhostname: This is apparently required at runtime, for some DNS lookup behaviour?
 # https://github.com/habitat-sh/core-plans/commit/7761ccef724292640d14143ccb0cd5466e877fa5
 unused-dependency = {ignored_packages = ["core/{ncurses,nss-myhostname}"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/interpreters/tcl/.hab-plan-config.toml
+++ b/packages/development/interpreters/tcl/.hab-plan-config.toml
@@ -4,5 +4,4 @@ missing-license = {level = "off", source-shasum = '8c0486668586672c5693d7d95817c
 # unused-runpath-entry = { ignored_files = ["lib/libtcl*.so"] }
 # TZ data is used at runtime
 unused-dependency = {ignored_packages = ["core/tzdata"]}
-# The rpath is added by the build system
-unused-runpath-entry = {ignored_files = ["lib/libtcl*.so*"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/acl/.hab-plan-config.toml
+++ b/packages/development/libraries/acl/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "760c61c68901b37fdd5eefeeaf4c0c7a26bdfdd8ac747a1edff1ce0e243c11af"}
 missing-license = {level = "off", source-shasum = "760c61c68901b37fdd5eefeeaf4c0c7a26bdfdd8ac747a1edff1ce0e243c11af"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/attr/.hab-plan-config.toml
+++ b/packages/development/libraries/attr/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "bae1c6949b258a0d68001367ce0c741cebdacdd3b62965d17e5eb23cd78adaf8"}
 missing-license = {level = "off", source-shasum = "bae1c6949b258a0d68001367ce0c741cebdacdd3b62965d17e5eb23cd78adaf8"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/cyrus-sasl/.hab-plan-config.toml
+++ b/packages/development/libraries/cyrus-sasl/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5"}
 missing-license = {level = "off", source-shasum = "26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/expat/.hab-plan-config.toml
+++ b/packages/development/libraries/expat/.hab-plan-config.toml
@@ -1,2 +1,2 @@
 [rules]
-unused-runpath-entry = {ignored_files = ["bin/xmlwf"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/gdbm/.hab-plan-config.toml
+++ b/packages/development/libraries/gdbm/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "f366c823a6724af313b6bbe975b2809f9a157e5f6a43612a72949138d161d762"}
 missing-license = {level = "off", source-shasum = "f366c823a6724af313b6bbe975b2809f9a157e5f6a43612a72949138d161d762"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/giflib/.hab-plan-config.toml
+++ b/packages/development/libraries/giflib/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/glibc/plan.sh
+++ b/packages/development/libraries/glibc/plan.sh
@@ -61,13 +61,25 @@ do_prepare() {
 	# of glibc. Thanks to https://github.com/NixOS/nixpkgs/pull/137601 for the solution.
 	patch -p1 <"$PLAN_CONTEXT/hab-nss-open-files.patch"
 
+	# 'HAB_LD_LINK_MODE' is used to control the way the habitat linker wrapper adds rpath entries.
+	# By setting it to '', we instruct the linker wrapper to add an rpath entry only if a library
+	# is going to be linked into the resulting binary or library.
+	# This setting is crucial when dealing with certain glibc ELF binaries/libraries. These are expected
+	# not to have a DT_RUNPATH entry, and using the '' mode ensures this expectation is met.
+	export HAB_LD_LINK_MODE="minimal"
+
 	# We cannot have RPATH set in the glibc binaries
 	# unset LD_RUN_PATH
 	unset LDFLAGS
 	unset CFLAGS
 	unset CXXFLAGS
 	unset CPPFLAGS
-	build_line "Unset CFLAGS, CXXFLAGS, CPPFLAGS and LDFLAGS"
+
+	build_line "Unsetting LDFLAGS"
+	build_line "Unsetting CFLAGS"
+	build_line "Unsetting CXXFLAGS"
+	build_line "Unsetting CPPFLAGS"
+	build_line "Setting HAB_LD_LINK_MODE=${HAB_LD_LINK_MODE}"
 }
 
 do_build() {

--- a/packages/development/libraries/isl/.hab-plan-config.toml
+++ b/packages/development/libraries/isl/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/jbigkit/.hab-plan-config.toml
+++ b/packages/development/libraries/jbigkit/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "de7106b6bfaf495d6865c7dd7ac6ca1381bd12e0d81405ea81e7f2167263d932"}
 missing-license = {level = "off", source-shasum = "de7106b6bfaf495d6865c7dd7ac6ca1381bd12e0d81405ea81e7f2167263d932"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/json-c/.hab-plan-config.toml
+++ b/packages/development/libraries/json-c/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/jsoncpp/.hab-plan-config.toml
+++ b/packages/development/libraries/jsoncpp/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/lerc/.hab-plan-config.toml
+++ b/packages/development/libraries/lerc/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libarchive/.hab-plan-config.toml
+++ b/packages/development/libraries/libarchive/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "5f245bd5176bc5f67428eb0aa497e09979264a153a074d35416521a5b8e86189"}
 missing-license = {level = "off", source-shasum = "5f245bd5176bc5f67428eb0aa497e09979264a153a074d35416521a5b8e86189"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libassuan/.hab-plan-config.toml
+++ b/packages/development/libraries/libassuan/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4"}
 missing-license = {level = "off", source-shasum = "8e8c2fcc982f9ca67dcbb1d95e2dc746b1739a4668bc20b3a3c5be632edb34e4"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libb2/.hab-plan-config.toml
+++ b/packages/development/libraries/libb2/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libbsd/.hab-plan-config.toml
+++ b/packages/development/libraries/libbsd/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "ff95cf8184151dacae4247832f8d4ea8800fa127dbd15033ecfe839f285b42a1"}
 missing-license = {level = "off", source-shasum = "ff95cf8184151dacae4247832f8d4ea8800fa127dbd15033ecfe839f285b42a1"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libdeflate/.hab-plan-config.toml
+++ b/packages/development/libraries/libdeflate/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libedit/.hab-plan-config.toml
+++ b/packages/development/libraries/libedit/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libevent/.hab-plan-config.toml
+++ b/packages/development/libraries/libevent/.hab-plan-config.toml
@@ -2,3 +2,4 @@
 duplicate-runtime-binary = {level = "off"}
 license-not-found = {level = "off", source-shasum = "92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb"}
 missing-license = {level = "off", source-shasum = "92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libffi/.hab-plan-config.toml
+++ b/packages/development/libraries/libffi/.hab-plan-config.toml
@@ -1,2 +1,3 @@
 [rules]
 missing-license = {level = "off", source-shasum = "540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libgpg-error/.hab-plan-config.toml
+++ b/packages/development/libraries/libgpg-error/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "a9ab83ca7acc442a5bd846a75b920285ff79bdb4e3d34aa382be88ed2c3aebaf"}
 missing-license = {level = "off", source-shasum = "a9ab83ca7acc442a5bd846a75b920285ff79bdb4e3d34aa382be88ed2c3aebaf"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libiconv/.hab-plan-config.toml
+++ b/packages/development/libraries/libiconv/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04"}
 missing-license = {level = "off", source-shasum = "e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libidn/.hab-plan-config.toml
+++ b/packages/development/libraries/libidn/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "de00b840f757cd3bb14dd9a20d5936473235ddcba06d4bc2da804654b8bbf0f6"}
 missing-license = {level = "off", source-shasum = "de00b840f757cd3bb14dd9a20d5936473235ddcba06d4bc2da804654b8bbf0f6"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libidn2/.hab-plan-config.toml
+++ b/packages/development/libraries/libidn2/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "76940cd4e778e8093579a9d195b25fff5e936e9dc6242068528b437a76764f91"}
 missing-license = {level = "off", source-shasum = "76940cd4e778e8093579a9d195b25fff5e936e9dc6242068528b437a76764f91"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libjpeg-turbo/.hab-plan-config.toml
+++ b/packages/development/libraries/libjpeg-turbo/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "b24890e2bb46e12e72a79f7e965f409f4e16466d00e1dd15d93d73ee6b592523"}
 missing-license = {level = "off", source-shasum = "b24890e2bb46e12e72a79f7e965f409f4e16466d00e1dd15d93d73ee6b592523"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libmd/.hab-plan-config.toml
+++ b/packages/development/libraries/libmd/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "f51c921042e34beddeded4b75557656559cf5b1f2448033b4c1eec11c07e530f"}
 missing-license = {level = "off", source-shasum = "f51c921042e34beddeded4b75557656559cf5b1f2448033b4c1eec11c07e530f"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libmpc/.hab-plan-config.toml
+++ b/packages/development/libraries/libmpc/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459"}
 missing-license = {level = "off", source-shasum = "17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libossp-uuid/.hab-plan-config.toml
+++ b/packages/development/libraries/libossp-uuid/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0"}
 missing-license = {level = "off", source-shasum = "11a615225baa5f8bb686824423f50e4427acd3f70d394765bdff32801f0fd5b0"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libpcre2/.hab-plan-config.toml
+++ b/packages/development/libraries/libpcre2/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libpng/.hab-plan-config.toml
+++ b/packages/development/libraries/libpng/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4"}
 missing-license = {level = "off", source-shasum = "daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libpsl/.hab-plan-config.toml
+++ b/packages/development/libraries/libpsl/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "ac6ce1e1fbd4d0254c4ddb9d37f1fa99dec83619c1253328155206b896210d4c"}
 missing-license = {level = "off", source-shasum = "ac6ce1e1fbd4d0254c4ddb9d37f1fa99dec83619c1253328155206b896210d4c"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/librhash/.hab-plan-config.toml
+++ b/packages/development/libraries/librhash/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "cc012bc860406dcf42f64431bcd3d2fa7560c02915a601aba9cd597a39329baa"}
 missing-license = {level = "off", source-shasum = "cc012bc860406dcf42f64431bcd3d2fa7560c02915a601aba9cd597a39329baa"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libseccomp/.hab-plan-config.toml
+++ b/packages/development/libraries/libseccomp/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "59065c8733364725e9721ba48c3a99bbc52af921daf48df4b1e012fbc7b10a76"}
 missing-license = {level = "off", source-shasum = "59065c8733364725e9721ba48c3a99bbc52af921daf48df4b1e012fbc7b10a76"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libsodium/.hab-plan-config.toml
+++ b/packages/development/libraries/libsodium/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libunistring/.hab-plan-config.toml
+++ b/packages/development/libraries/libunistring/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7"}
 missing-license = {level = "off", source-shasum = "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libuv/.hab-plan-config.toml
+++ b/packages/development/libraries/libuv/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764"}
 missing-license = {level = "off", source-shasum = "371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libwebp/.hab-plan-config.toml
+++ b/packages/development/libraries/libwebp/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4"}
 missing-license = {level = "off", source-shasum = "daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libxml2/.hab-plan-config.toml
+++ b/packages/development/libraries/libxml2/.hab-plan-config.toml
@@ -3,3 +3,4 @@
 host-script-interpreter = {ignored_files = ["share/doc/libxml2*"]}
 license-not-found = {level = "off", source-shasum = "c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92"}
 missing-license = {level = "off", source-shasum = "c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libxslt/.hab-plan-config.toml
+++ b/packages/development/libraries/libxslt/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f"}
 missing-license = {level = "off", source-shasum = "98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/libyaml/.hab-plan-config.toml
+++ b/packages/development/libraries/libyaml/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"}
 missing-license = {level = "off", source-shasum = "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/lzo/.hab-plan-config.toml
+++ b/packages/development/libraries/lzo/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072"}
 missing-license = {level = "off", source-shasum = "c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/mpfr/.hab-plan-config.toml
+++ b/packages/development/libraries/mpfr/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"}
 missing-license = {level = "off", source-shasum = "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/musl/.hab-plan-config.toml
+++ b/packages/development/libraries/musl/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/nettle/.hab-plan-config.toml
+++ b/packages/development/libraries/nettle/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "661f5eb03f048a3b924c3a8ad2515d4068e40f67e774e8a26827658007e3bcf0"}
 missing-license = {level = "off", source-shasum = "661f5eb03f048a3b924c3a8ad2515d4068e40f67e774e8a26827658007e3bcf0"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/nghttp2/.hab-plan-config.toml
+++ b/packages/development/libraries/nghttp2/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "4b6d11c85f2638531d1327fe1ed28c1e386144e8841176c04153ed32a4878208"}
 missing-license = {level = "off", source-shasum = "4b6d11c85f2638531d1327fe1ed28c1e386144e8841176c04153ed32a4878208"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/nss-myhostname/.hab-plan-config.toml
+++ b/packages/development/libraries/nss-myhostname/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "2ba744ea8d578d1c57c85884e94a3042ee17843a5294434d3a7f6c4d67e7caf2"}
 missing-license = {level = "off", source-shasum = "2ba744ea8d578d1c57c85884e94a3042ee17843a5294434d3a7f6c4d67e7caf2"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/oniguruma/.hab-plan-config.toml
+++ b/packages/development/libraries/oniguruma/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/openssl/1.1/.hab-plan-config.toml
+++ b/packages/development/libraries/openssl/1.1/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5"}
 missing-license = {level = "off", source-shasum = "892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/openssl/default/aarch64-linux/.hab-plan-config.toml
+++ b/packages/development/libraries/openssl/default/aarch64-linux/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e"}
 missing-license = {level = "off", source-shasum = "83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/proj/.hab-plan-config.toml
+++ b/packages/development/libraries/proj/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/protobuf-c/.hab-plan-config.toml
+++ b/packages/development/libraries/protobuf-c/.hab-plan-config.toml
@@ -1,4 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "26d98ee9bf18a6eba0d3f855ddec31dbe857667d269bc0b6017335572f85bbcb"}
 missing-license = {level = "off", source-shasum = "26d98ee9bf18a6eba0d3f855ddec31dbe857667d269bc0b6017335572f85bbcb"}
-unused-runpath-entry = {ignored_files = ["lib/*"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/xxhash/.hab-plan-config.toml
+++ b/packages/development/libraries/xxhash/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "3bb6b7d6f30c591dd65aaaff1c8b7a5b94d81687998ca9400082c739a690436c"}
 missing-license = {level = "off", source-shasum = "3bb6b7d6f30c591dd65aaaff1c8b7a5b94d81687998ca9400082c739a690436c"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/libraries/zlib/.hab-plan-config.toml
+++ b/packages/development/libraries/zlib/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff"}
 missing-license = {level = "off", source-shasum = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/tools/build-managers/cmake/.hab-plan-config.toml
+++ b/packages/development/tools/build-managers/cmake/.hab-plan-config.toml
@@ -6,3 +6,4 @@ license-not-found = {level = "off", source-shasum = "d9570a95c215f4c9886dd0f0564
 missing-license = {level = "off", source-shasum = "d9570a95c215f4c9886dd0f0564ca4ef8d18c30750f157238ea12669c2985978"}
 script-interpreter-not-found = {ignored_files = ["share/cmake-*/Modules/*"]}
 unused-dependency = {ignored_packages = ["core/nghttp2", "core/bzip2", "core/openssl", "core/zstd", "core/xz"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/tools/misc/binutils/.hab-plan-config.toml
+++ b/packages/development/tools/misc/binutils/.hab-plan-config.toml
@@ -5,3 +5,4 @@ unused-dependency = {ignored_packages = [
     "core/bash-static",
     "core/hab-ld-wrapper"
 ]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/tools/misc/libtool/.hab-plan-config.toml
+++ b/packages/development/tools/misc/libtool/.hab-plan-config.toml
@@ -5,3 +5,4 @@ missing-license = {level = "off", source-shasum = "e3bd4d5d3d025a36c21dd6af7ea81
 unused-dependency = {ignored_packages = [
     "core/{coreutils,m4,binutils,sed,grep,file}"
 ]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/tools/misc/texinfo/.hab-plan-config.toml
+++ b/packages/development/tools/misc/texinfo/.hab-plan-config.toml
@@ -3,5 +3,4 @@ license-not-found = {level = "off", source-shasum = "8eb753ed28bca21f8f56c1a1803
 missing-license = {level = "off", source-shasum = "8eb753ed28bca21f8f56c1a180362aed789229bd62fff58bf8368e9beb59fec4"}
 # gawk is used by the texindex binary
 unused-dependency = {ignored_packages = ["core/gawk"]}
-# The perl library runpath is added to the rpath by the build system
-unused-runpath-entry = {ignored_files = ["lib/*"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/tools/misc/valgrind/.hab-plan-config.toml
+++ b/packages/development/tools/misc/valgrind/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "00859aa13a772eddf7822225f4b46ee0d39afbe071d32778da4d99984081f7f5"}
 missing-license = {level = "off", source-shasum = "00859aa13a772eddf7822225f4b46ee0d39afbe071d32778da4d99984081f7f5"}
+unused-runpath-entry = {level = "off"}

--- a/packages/development/tools/parsers/flex/.hab-plan-config.toml
+++ b/packages/development/tools/parsers/flex/.hab-plan-config.toml
@@ -1,2 +1,3 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995"}
+unused-runpath-entry = {level = "off"}

--- a/packages/os-specific/linux/libcap/.hab-plan-config.toml
+++ b/packages/os-specific/linux/libcap/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "5210a3c3caee54bf59e3724cac4a5c805579aefb3d91bf851fde8e921eabba8b"}
 missing-license = {level = "off", source-shasum = "5210a3c3caee54bf59e3724cac4a5c805579aefb3d91bf851fde8e921eabba8b"}
+unused-runpath-entry = {level = "off"}

--- a/packages/os-specific/linux/procps-ng/.hab-plan-config.toml
+++ b/packages/os-specific/linux/procps-ng/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "4518b3e7aafd34ec07d0063d250fd474999b20b200218c3ae56f5d2113f141b4"}
 missing-license = {level = "off", source-shasum = "4518b3e7aafd34ec07d0063d250fd474999b20b200218c3ae56f5d2113f141b4"}
+unused-runpath-entry = {level = "off"}

--- a/packages/os-specific/linux/psmisc/.hab-plan-config.toml
+++ b/packages/os-specific/linux/psmisc/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "7f0cceeace2050c525f3ebb35f3ba01d618b8d690620580bdb8cd8269a0c1679"}
 missing-license = {level = "off", source-shasum = "7f0cceeace2050c525f3ebb35f3ba01d618b8d690620580bdb8cd8269a0c1679"}
+unused-runpath-entry = {level = "off"}

--- a/packages/os-specific/linux/shadow/.hab-plan-config.toml
+++ b/packages/os-specific/linux/shadow/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "feec1f2ce9c1b62798afd35a7d1b04cefdfa3a0a30ff3e75d6965ba8978c9144"}
 missing-license = {level = "off", source-shasum = "feec1f2ce9c1b62798afd35a7d1b04cefdfa3a0a30ff3e75d6965ba8978c9144"}
+unused-runpath-entry = {level = "off"}

--- a/packages/os-specific/linux/util-linux/.hab-plan-config.toml
+++ b/packages/os-specific/linux/util-linux/.hab-plan-config.toml
@@ -3,3 +3,4 @@
 host-script-interpreter = {ignored_files = ["*-example.{bash,tcsh}"]}
 license-not-found = {level = "off", source-shasum = "bd07b7e98839e0359842110525a3032fdb8eaf3a90bedde3dd1652d32d15cce5"}
 missing-license = {level = "off", source-shasum = "bd07b7e98839e0359842110525a3032fdb8eaf3a90bedde3dd1652d32d15cce5"}
+unused-runpath-entry = {level = "off"}

--- a/packages/shells/bash/shared/.hab-plan-config.toml
+++ b/packages/shells/bash/shared/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "cc012bc860406dcf42f64431bcd3d2fa7560c02915a601aba9cd597a39329baa"}
 missing-license = {level = "off", source-shasum = "cc012bc860406dcf42f64431bcd3d2fa7560c02915a601aba9cd597a39329baa"}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/archivers/tar/.hab-plan-config.toml
+++ b/packages/tools/archivers/tar/.hab-plan-config.toml
@@ -3,3 +3,4 @@ license-not-found = {level = "off", source-shasum = "03d908cf5768cfe6b7ad588c921
 missing-license = {level = "off", source-shasum = "03d908cf5768cfe6b7ad588c921c6ed21acabfb2b79b788d1330453507647aed"}
 # All these packages contain binaries used by tar at runtime
 unused-dependency = {ignored_packages = ["core/{xz,zstd,bzip2,lzip,gzip,lzop,attr,acl}"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/archivers/unzip/.hab-plan-config.toml
+++ b/packages/tools/archivers/unzip/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/compression/bzip2/.hab-plan-config.toml
+++ b/packages/tools/compression/bzip2/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/compression/lz4/.hab-plan-config.toml
+++ b/packages/tools/compression/lz4/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "030644df4611007ff7dc962d981f390361e6c97a34e5cbc393ddfbe019ffe2c1"}
 missing-license = {level = "off", source-shasum = "030644df4611007ff7dc962d981f390361e6c97a34e5cbc393ddfbe019ffe2c1"}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/compression/xz/.hab-plan-config.toml
+++ b/packages/tools/compression/xz/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"}
 missing-license = {level = "off", source-shasum = "f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/compression/zstd/.hab-plan-config.toml
+++ b/packages/tools/compression/zstd/.hab-plan-config.toml
@@ -3,3 +3,4 @@ license-not-found = {level = "off", source-shasum = "0d9ade222c64e912d6957b11c92
 missing-license = {level = "off", source-shasum = "0d9ade222c64e912d6957b11c923e214e2e010a18f39bec102f572e693ba2867"}
 # less and grep are used in script within the zstd package
 unused-dependency = {ignored_packages = ["core/{less,grep}"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/filesystems/e2fsprogs/.hab-plan-config.toml
+++ b/packages/tools/filesystems/e2fsprogs/.hab-plan-config.toml
@@ -2,4 +2,4 @@
 license-not-found = {level = "off", source-shasum = "c011bf3bf4ae5efe9fa2b0e9b0da0c14ef4b79c6143c1ae6d9f027931ec7abe1"}
 missing-license = {level = "off", source-shasum = "c011bf3bf4ae5efe9fa2b0e9b0da0c14ef4b79c6143c1ae6d9f027931ec7abe1"}
 # Ignore lib folder runpath entry added by the build system
-unused-runpath-entry = {ignored_files = ["lib/*", "sbin/*"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/habitat/hab-launcher/.hab-plan-config.toml
+++ b/packages/tools/habitat/hab-launcher/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/habitat/hab-sup/.hab-plan-config.toml
+++ b/packages/tools/habitat/hab-sup/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "ba63a6638fb181c6a7f24d8efb5f5750a648d85fa9456a4a3a9be71471f098f1"}
 missing-license = {level = "off", source-shasum = "ba63a6638fb181c6a7f24d8efb5f5750a648d85fa9456a4a3a9be71471f098f1"}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/misc/coreutils/.hab-plan-config.toml
+++ b/packages/tools/misc/coreutils/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa"}
 missing-license = {level = "off", source-shasum = "4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa"}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/misc/file/.hab-plan-config.toml
+++ b/packages/tools/misc/file/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "13e532c7b364f7d57e23dfeea3147103150cb90593a57af86c10e4f6e411603f"}
 missing-license = {level = "off", source-shasum = "13e532c7b364f7d57e23dfeea3147103150cb90593a57af86c10e4f6e411603f"}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/misc/less/.hab-plan-config.toml
+++ b/packages/tools/misc/less/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "6aadf54be8bf57d0e2999a3c5d67b1de63808bb90deb8f77b028eafae3a08e10"}
 missing-license = {level = "off", source-shasum = "6aadf54be8bf57d0e2999a3c5d67b1de63808bb90deb8f77b028eafae3a08e10"}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/networking/curl/.hab-plan-config.toml
+++ b/packages/tools/networking/curl/.hab-plan-config.toml
@@ -1,5 +1,4 @@
 [rules]
 # This is needed for SSL certificate verification
 unused-dependency = {ignored_packages = ["core/cacerts"]}
-# The build system adds a runpath entry to libunistring's lib folder
-unused-runpath-entry = {ignored_files = ["lib/libcurl.so*"]}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/networking/inetutils/.hab-plan-config.toml
+++ b/packages/tools/networking/inetutils/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "849d96f136effdef69548a940e3e0ec0624fc0c81265296987986a0dd36ded37"}
 missing-license = {level = "off", source-shasum = "849d96f136effdef69548a940e3e0ec0624fc0c81265296987986a0dd36ded37"}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/text/gawk/.hab-plan-config.toml
+++ b/packages/tools/text/gawk/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "03a0360edcd84bec156fe211bbc4fc8c78790973ce4e8b990a11d778d40b1a26"}
 missing-license = {level = "off", source-shasum = "03a0360edcd84bec156fe211bbc4fc8c78790973ce4e8b990a11d778d40b1a26"}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/text/groff/.hab-plan-config.toml
+++ b/packages/tools/text/groff/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "e78e7b4cb7dec310849004fa88847c44701e8d133b5d4c13057d876c1bad0293"}
 missing-license = {level = "off", source-shasum = "e78e7b4cb7dec310849004fa88847c44701e8d133b5d4c13057d876c1bad0293"}
+unused-runpath-entry = {level = "off"}

--- a/packages/tools/text/pcre2/.hab-plan-config.toml
+++ b/packages/tools/text/pcre2/.hab-plan-config.toml
@@ -1,1 +1,2 @@
-
+[rules]
+unused-runpath-entry = {level = "off"}

--- a/version-check.sh
+++ b/version-check.sh
@@ -7,28 +7,30 @@ echo "/bin/sh -> $MYSH"
 echo $MYSH | grep -q bash || echo "ERROR: /bin/sh does not point to bash"
 unset MYSH
 
-echo -n "Binutils: "; ld --version | head -n1 | cut -d" " -f3-
+echo -n "Binutils: "
+ld --version | head -n1 | cut -d" " -f3-
 bison --version | head -n1
 
 if [ -h /usr/bin/yacc ]; then
-  echo "/usr/bin/yacc -> `readlink -f /usr/bin/yacc`";
+	echo "/usr/bin/yacc -> $(readlink -f /usr/bin/yacc)"
 elif [ -x /usr/bin/yacc ]; then
-  echo yacc is `/usr/bin/yacc --version | head -n1`
+	echo yacc is $(/usr/bin/yacc --version | head -n1)
 else
-  echo "yacc not found"
+	echo "yacc not found"
 fi
 
-echo -n "Coreutils: "; chown --version | head -n1 | cut -d")" -f2
+echo -n "Coreutils: "
+chown --version | head -n1 | cut -d")" -f2
 diff --version | head -n1
 find --version | head -n1
 gawk --version | head -n1
 
 if [ -h /usr/bin/awk ]; then
-  echo "/usr/bin/awk -> `readlink -f /usr/bin/awk`";
+	echo "/usr/bin/awk -> $(readlink -f /usr/bin/awk)"
 elif [ -x /usr/bin/awk ]; then
-  echo awk is `/usr/bin/awk --version | head -n1`
+	echo awk is $(/usr/bin/awk --version | head -n1)
 else
-  echo "awk not found"
+	echo "awk not found"
 fi
 
 gcc --version | head -n1
@@ -39,15 +41,15 @@ cat /proc/version
 m4 --version | head -n1
 make --version | head -n1
 patch --version | head -n1
-echo Perl `perl -V:version`
+echo Perl $(perl -V:version)
 python3 --version
 sed --version | head -n1
 tar --version | head -n1
-makeinfo --version | head -n1  # texinfo version
+makeinfo --version | head -n1 # texinfo version
 xz --version | head -n1
 
-echo 'int main(){}' > dummy.c && g++ -o dummy dummy.c
-if [ -x dummy ]
-  then echo "g++ compilation OK";
-  else echo "g++ compilation failed"; fi
+echo 'int main(){}' >dummy.c && g++ -o dummy dummy.c
+if [ -x dummy ]; then
+	echo "g++ compilation OK"
+else echo "g++ compilation failed"; fi
 rm -f dummy.c dummy


### PR DESCRIPTION
Restore the old linker behavior as the default behavior ensuring compatibility for existing plans such as chef/chef-infra-client that depend on it for dynamic loading scenarios.