### PR TITLE
minio bumped to 2023-09-23T03-47-50Z

### DIFF
--- a/packages/applications/databases/minio/.hab-plan-config.toml
+++ b/packages/applications/databases/minio/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 license-not-found = {level = "off", source-shasum = "cdb692133cec30d6b446a1f564c7e1932e572c157b39a7d2ea676275e6c5b883"}
 missing-license = {level = "off", source-shasum = "cdb692133cec30d6b446a1f564c7e1932e572c157b39a7d2ea676275e6c5b883"}
+

--- a/packages/applications/databases/minio/.hab-plan-config.toml
+++ b/packages/applications/databases/minio/.hab-plan-config.toml
@@ -1,3 +1,3 @@
 [rules]
-license-not-found = {level = "off", source-shasum = "016f8b5ba0f9843e3f745a7b4b32663407d01e89f5b27aa1979af69bd3844df5"}
-missing-license = {level = "off", source-shasum = "016f8b5ba0f9843e3f745a7b4b32663407d01e89f5b27aa1979af69bd3844df5"}
+license-not-found = {level = "off", source-shasum = "cdb692133cec30d6b446a1f564c7e1932e572c157b39a7d2ea676275e6c5b883"}
+missing-license = {level = "off", source-shasum = "cdb692133cec30d6b446a1f564c7e1932e572c157b39a7d2ea676275e6c5b883"}

--- a/packages/applications/databases/minio/plan.sh
+++ b/packages/applications/databases/minio/plan.sh
@@ -1,10 +1,10 @@
 pkg_name="minio"
 pkg_origin="core"
-pkg_version="2021-11-03T03-36-36Z"
+pkg_version="2023-09-23T03-47-50Z"
 pkg_description="Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure."
 pkg_upstream_url="https://minio.io"
 pkg_source="https://dl.minio.io/server/minio/release/linux-arm64/archive/minio.RELEASE.${pkg_version}"
-pkg_shasum="016f8b5ba0f9843e3f745a7b4b32663407d01e89f5b27aa1979af69bd3844df5"
+pkg_shasum="cdb692133cec30d6b446a1f564c7e1932e572c157b39a7d2ea676275e6c5b883"
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
core/minio bumped in core-plans repo for fixing CVE-2023-28434. 
https://github.com/habitat-sh/core-plans/pull/4625
So same version is updated in core-packages repo.