### PR TITLE
Fixing build errors of sccache and protobuf-rust built with hab-auto-build tool

### DIFF
--- a/packages/development/libraries/protobuf-rust/plan.sh
+++ b/packages/development/libraries/protobuf-rust/plan.sh
@@ -8,7 +8,7 @@ pkg_upstream_url="https://github.com/stepancheg/rust-protobuf"
 pkg_description="Rust implementation of Google protocol buffers"
 pkg_deps=(
   core/glibc
-  core/gcc-libs
+  core/gcc-base
 )
 pkg_build_deps=(
   core/rust

--- a/packages/tools/misc/sccache/plan.sh
+++ b/packages/tools/misc/sccache/plan.sh
@@ -10,7 +10,7 @@ pkg_shasum=30b951b49246d5ca7d614e5712215cb5f39509d6f899641f511fb19036b5c4e5
 pkg_bin_dirs=(bin)
 pkg_deps=(
   core/glibc
-  core/gcc-libs
+  core/gcc-base
   core/openssl
 )
 pkg_build_deps=(


### PR DESCRIPTION
Fixed the errors when built with hab-auto-build tool.