### PR TITLE
nspr bumped to latest version 4.35

### DIFF
--- a/packages/development/libraries/nspr/.hab-plan-config.toml
+++ b/packages/development/libraries/nspr/.hab-plan-config.toml
@@ -1,5 +1,5 @@
 [rules]
-license-not-found = {level = "off", source-shasum = "ecc632bc578c125650999776673eeff952096afa6d151f6d91f6c3a93e1e716a"}
-missing-license = {level = "off", source-shasum = "ecc632bc578c125650999776673eeff952096afa6d151f6d91f6c3a93e1e716a"}
+license-not-found = {level = "off", source-shasum = "7ea3297ea5969b5d25a5dd8d47f2443cda88e9ee746301f6e1e1426f8a6abc8f"}
+missing-license = {level = "off", source-shasum = "7ea3297ea5969b5d25a5dd8d47f2443cda88e9ee746301f6e1e1426f8a6abc8f"}
 host-script-interpreter = {level = "off"}
 unused-runpath-entry = "off"

--- a/packages/development/libraries/nspr/plan.sh
+++ b/packages/development/libraries/nspr/plan.sh
@@ -1,13 +1,13 @@
 program=nspr
 pkg_name=nspr
 pkg_origin=core
-pkg_version=4.9
+pkg_version=4.35
 pkg_license=("MPL-2.0")
 pkg_description="Netscape Portable Runtime"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_upstream_url=https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
 pkg_source=https://ftp.mozilla.org/pub/nspr/releases/v${pkg_version}/src/${pkg_name}-${pkg_version}.tar.gz
-pkg_shasum=ecc632bc578c125650999776673eeff952096afa6d151f6d91f6c3a93e1e716a
+pkg_shasum=7ea3297ea5969b5d25a5dd8d47f2443cda88e9ee746301f6e1e1426f8a6abc8f
 pkg_deps=(core/glibc)
 pkg_build_deps=(
   core/gcc
@@ -18,7 +18,7 @@ pkg_include_dirs=(include/nspr)
 pkg_lib_dirs=(lib)
 
 do_build() {
-  ./mozilla/nsprpub/configure --prefix="${pkg_prefix}" \
+  ./nspr/configure --prefix="${pkg_prefix}" \
                    --enable-optimize \
                    --disable-debug \
                    --enable-64bit


### PR DESCRIPTION
nspr bumped to latest version 4.35. Version given by security team was lower 4.9.