### PR TITLE
Fixing the hab-auto-build errors. Rust bumped to 1.79.0

### DIFF
--- a/packages/development/compilers/rust/glibc/.hab-plan-config.toml
+++ b/packages/development/compilers/rust/glibc/.hab-plan-config.toml
@@ -1,7 +1,11 @@
 [rules]
-missing-license = {level = "off", source-shasum = "473978b6f8ff216389f9e89315211c6b683cf95a966196e7914b46e8cf0d74f6"}
+missing-license = {level = "off", source-shasum = "628efa8ef0658a7c4199883ee132281f19931448d3cfee4ecfd768898fe74c18"}
 # Some rust files in the docs start with #![feature(...)] which is misinterpreted as a script
 script-interpreter-not-found = {ignored_files = ["*.rs"]}
+library-dependency-not-found = {ignored_files = ["lib/*"]}
+unused-runpath-entry = {ignored_files = ["lib/*"]}
+unused-rpath-entry = {ignored_files = ["lib/*"]}
+host-elf-interpreter = {level = "off"}
 # The following dependencies are needed at runtime by Cargo for the associated reasons:
 # 1. core/cacerts - Provides SSL certificates necessary for secure connections.
 # 2. core/binutils - Supplies the 'ld' linker, utilized indirectly by Rust through gcc.

--- a/packages/development/libraries/userspace-rcu/.hab-plan-config.toml
+++ b/packages/development/libraries/userspace-rcu/.hab-plan-config.toml
@@ -1,2 +1,4 @@
 [rules]
+license-not-found = {level = "off", source-shasum = "ca43bf261d4d392cff20dfae440836603bf009fce24fdc9b2697d837a2239d4f"}
+missing-license = {level = "off", source-shasum = "ca43bf261d4d392cff20dfae440836603bf009fce24fdc9b2697d837a2239d4f"}
 unused-runpath-entry = {ignored_files = ["bin/*", "lib/*"]}

--- a/packages/os-specific/linux/net-tools/.hab-plan-config.toml
+++ b/packages/os-specific/linux/net-tools/.hab-plan-config.toml
@@ -1,1 +1,3 @@
 [rules]
+license-not-found = {level = "off", source-shasum = "b262435a5241e89bfa51c3cabd5133753952f7a7b7b93f32e08cb9d96f580d69"}
+missing-license = {level = "off", source-shasum = "b262435a5241e89bfa51c3cabd5133753952f7a7b7b93f32e08cb9d96f580d69"}


### PR DESCRIPTION
Fixing the hab-auto-build errors. adding rules. 
Adding the rules as rust is bumped to 1.79.0 and added rust-must target by Matt.