### PR TITLE
update hab to use tag 1.6.1108

### DIFF
--- a/packages/bootstrap/build-support/hab-cc-wrapper/plan.sh
+++ b/packages/bootstrap/build-support/hab-cc-wrapper/plan.sh
@@ -1,5 +1,4 @@
 # shellcheck disable=2154
-commit_hash="f240ff4fe4dc687da7f51741640e513233ddebc6"
 native_target="${TARGET_ARCH:-${pkg_target%%-*}}-hab-linux-gnu"
 
 pkg_name="hab-cc-wrapper"
@@ -7,9 +6,9 @@ pkg_origin="core"
 pkg_version="1.0.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/hab-pkg-wrappers/archive/${commit_hash}.tar.gz"
-pkg_shasum="745ad24f2cce4f9a4727f77537110c477fd79fd41a092e6a0d1fec0318a68c19"
-pkg_dirname="hab-pkg-wrappers-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/hab-pkg-wrappers/archive/v${pkg_version}.tar.gz"
+pkg_shasum="4fc7d658f0241bebda8393e48e4ea8a2bbce8c60ca3286cc26d6fec8e782c1c6"
+pkg_dirname="hab-pkg-wrappers-${pkg_version}"
 pkg_build_deps=(
 	core/native-rust
 )

--- a/packages/bootstrap/build-support/hab-ld-wrapper/plan.sh
+++ b/packages/bootstrap/build-support/hab-ld-wrapper/plan.sh
@@ -1,5 +1,4 @@
 # shellcheck disable=2154
-commit_hash="f240ff4fe4dc687da7f51741640e513233ddebc6"
 native_target="${TARGET_ARCH:-${pkg_target%%-*}}-hab-linux-gnu"
 
 pkg_name="hab-ld-wrapper"
@@ -7,9 +6,9 @@ pkg_origin="core"
 pkg_version="1.0.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/hab-pkg-wrappers/archive/${commit_hash}.tar.gz"
-pkg_shasum="745ad24f2cce4f9a4727f77537110c477fd79fd41a092e6a0d1fec0318a68c19"
-pkg_dirname="hab-pkg-wrappers-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/hab-pkg-wrappers/archive/v${pkg_version}.tar.gz"
+pkg_shasum="4fc7d658f0241bebda8393e48e4ea8a2bbce8c60ca3286cc26d6fec8e782c1c6"
+pkg_dirname="hab-pkg-wrappers-${pkg_version}"
 pkg_build_deps=(
 	core/native-rust
 )

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-hab-backline/plan.sh
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-hab-backline/plan.sh
@@ -1,12 +1,12 @@
-commit_hash="21914065e338e2ce9fb4880b92326abfa79737aa"
+_version="1.6.1108"
 
 pkg_name="build-tools-hab-backline"
 pkg_origin="core"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/habitat/archive/${commit_hash}.tar.gz"
-pkg_shasum="12674359e72fc8a87b5a51dd24119b00abffa1566a9a151637ffe3d9351808ee"
-pkg_dirname="habitat-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/habitat/archive/refs/tags/${_version}.tar.gz"
+pkg_shasum="5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"
+pkg_dirname="habitat-${_version}"
 
 pkg_build_deps=()
 

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-hab-plan-build/plan.sh
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-hab-plan-build/plan.sh
@@ -1,13 +1,13 @@
 # shellcheck disable=2034
-commit_hash="21914065e338e2ce9fb4880b92326abfa79737aa"
+_version="1.6.1108"
 
 pkg_name="build-tools-hab-plan-build"
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/habitat/archive/${commit_hash}.tar.gz"
-pkg_shasum="12674359e72fc8a87b5a51dd24119b00abffa1566a9a151637ffe3d9351808ee"
-pkg_dirname="habitat-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/habitat/archive/refs/tags/${_version}.tar.gz"
+pkg_shasum="5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"
+pkg_dirname="habitat-${_version}"
 
 pkg_bin_dirs=(bin)
 

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-hab-studio/plan.sh
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-hab-studio/plan.sh
@@ -1,13 +1,13 @@
 # shellcheck disable=2034
-commit_hash="21914065e338e2ce9fb4880b92326abfa79737aa"
+_version="1.6.1108"
 
 pkg_name="build-tools-hab-studio"
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/habitat/archive/${commit_hash}.tar.gz"
-pkg_shasum="12674359e72fc8a87b5a51dd24119b00abffa1566a9a151637ffe3d9351808ee"
-pkg_dirname="habitat-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/habitat/archive/refs/tags/${_version}.tar.gz"
+pkg_shasum="5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"
+pkg_dirname="habitat-${_version}"
 
 pkg_deps=(
 	core/build-tools-hab-backline

--- a/packages/bootstrap/build-tools/cross-tools/build-tools-hab/plan.sh
+++ b/packages/bootstrap/build-tools/cross-tools/build-tools-hab/plan.sh
@@ -1,14 +1,14 @@
 # shellcheck disable=2154
-commit_hash="21914065e338e2ce9fb4880b92326abfa79737aa"
+_version="1.6.1108"
 native_target="${TARGET_ARCH:-${pkg_target%%-*}}-hab-linux-gnu"
 
 pkg_name="build-tools-hab"
 pkg_origin="core"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/habitat/archive/${commit_hash}.tar.gz"
-pkg_shasum="12674359e72fc8a87b5a51dd24119b00abffa1566a9a151637ffe3d9351808ee"
-pkg_dirname="habitat-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/habitat/archive/refs/tags/${_version}.tar.gz"
+pkg_shasum="5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"
+pkg_dirname="habitat-${_version}"
 # The result is a portable, static binary in a zero-dependency package.
 pkg_deps=(
 	core/build-tools-glibc

--- a/packages/tools/habitat/hab-backline/plan.sh
+++ b/packages/tools/habitat/hab-backline/plan.sh
@@ -1,14 +1,14 @@
 # shellcheck disable=2034
 git_url="https://github.com/habitat-sh/habitat.git"
-commit_hash="94d6d50138d1fe005e59f4a7117974ce1b977ae2"
-pkg_shasum="ba63a6638fb181c6a7f24d8efb5f5750a648d85fa9456a4a3a9be71471f098f1"
+_version="1.6.1108"
+pkg_shasum="5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"
 
 pkg_name="hab-backline"
 pkg_origin="core"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/habitat/archive/${commit_hash}.tar.gz"
-pkg_dirname="habitat-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/habitat/archive/refs/tags/${_version}.tar.gz"
+pkg_dirname="habitat-${_version}"
 
 pkg_build_deps=()
 

--- a/packages/tools/habitat/hab-launcher/plan.sh
+++ b/packages/tools/habitat/hab-launcher/plan.sh
@@ -1,14 +1,14 @@
 # shellcheck disable=2034
 git_url="https://github.com/habitat-sh/habitat.git"
-commit_hash="94d6d50138d1fe005e59f4a7117974ce1b977ae2"
-pkg_shasum="ba63a6638fb181c6a7f24d8efb5f5750a648d85fa9456a4a3a9be71471f098f1"
+_version="1.6.1108"
+pkg_shasum="5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"
 
 pkg_name="hab-launcher"
 pkg_origin="core"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/habitat/archive/${commit_hash}.tar.gz"
-pkg_dirname="habitat-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/habitat/archive/refs/tags/${_version}.tar.gz"
+pkg_dirname="habitat-${_version}"
 
 pkg_deps=(
 	core/glibc
@@ -35,7 +35,7 @@ pkg_version() {
 		--git-dir="$HAB_CACHE_SRC_PATH/$pkg_dirname-git" \
 		rev-list "$(git \
 			--git-dir="$HAB_CACHE_SRC_PATH/$pkg_dirname-git" \
-			rev-parse $commit_hash)" \
+			rev-parse ${_version})" \
 		--count
 }
 

--- a/packages/tools/habitat/hab-plan-build/plan.sh
+++ b/packages/tools/habitat/hab-plan-build/plan.sh
@@ -1,14 +1,14 @@
 # shellcheck disable=2034
 git_url="https://github.com/habitat-sh/habitat.git"
-commit_hash="94d6d50138d1fe005e59f4a7117974ce1b977ae2"
-pkg_shasum="ba63a6638fb181c6a7f24d8efb5f5750a648d85fa9456a4a3a9be71471f098f1"
+_version="1.6.1108"
+pkg_shasum="5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"
 
 pkg_name="hab-plan-build"
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/habitat/archive/${commit_hash}.tar.gz"
-pkg_dirname="habitat-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/habitat/archive/refs/tags/${_version}.tar.gz"
+pkg_dirname="habitat-${_version}"
 
 pkg_bin_dirs=(bin)
 

--- a/packages/tools/habitat/hab-studio/plan.sh
+++ b/packages/tools/habitat/hab-studio/plan.sh
@@ -1,14 +1,14 @@
 # shellcheck disable=2034
 git_url="https://github.com/habitat-sh/habitat.git"
-commit_hash="94d6d50138d1fe005e59f4a7117974ce1b977ae2"
-pkg_shasum="ba63a6638fb181c6a7f24d8efb5f5750a648d85fa9456a4a3a9be71471f098f1"
+_version="1.6.1108"
+pkg_shasum="5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"
 
 pkg_name="hab-studio"
 pkg_origin="core"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/habitat/archive/${commit_hash}.tar.gz"
-pkg_dirname="habitat-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/habitat/archive/refs/tags/${_version}.tar.gz"
+pkg_dirname="habitat-${_version}"
 
 pkg_deps=(
 	core/hab-backline

--- a/packages/tools/habitat/hab-sup/.hab-plan-config.toml
+++ b/packages/tools/habitat/hab-sup/.hab-plan-config.toml
@@ -1,4 +1,4 @@
 [rules]
-license-not-found = {level = "off", source-shasum = "ba63a6638fb181c6a7f24d8efb5f5750a648d85fa9456a4a3a9be71471f098f1"}
-missing-license = {level = "off", source-shasum = "ba63a6638fb181c6a7f24d8efb5f5750a648d85fa9456a4a3a9be71471f098f1"}
+license-not-found = {level = "off", source-shasum = "5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"}
+missing-license = {level = "off", source-shasum = "5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"}
 unused-runpath-entry = {level = "off"}

--- a/packages/tools/habitat/hab-sup/plan.sh
+++ b/packages/tools/habitat/hab-sup/plan.sh
@@ -1,14 +1,14 @@
 # shellcheck disable=2034
 git_url="https://github.com/habitat-sh/habitat.git"
-commit_hash="94d6d50138d1fe005e59f4a7117974ce1b977ae2"
-pkg_shasum="ba63a6638fb181c6a7f24d8efb5f5750a648d85fa9456a4a3a9be71471f098f1"
+_version="1.6.1108"
+pkg_shasum="5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"
 
 pkg_name="hab-sup"
 pkg_origin="core"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/habitat/archive/${commit_hash}.tar.gz"
-pkg_dirname="habitat-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/habitat/archive/refs/tags/${_version}.tar.gz"
+pkg_dirname="habitat-${_version}"
 
 pkg_deps=(
 	core/glibc

--- a/packages/tools/habitat/hab/plan.sh
+++ b/packages/tools/habitat/hab/plan.sh
@@ -1,14 +1,14 @@
 # shellcheck disable=2034
 git_url="https://github.com/habitat-sh/habitat.git"
-commit_hash="94d6d50138d1fe005e59f4a7117974ce1b977ae2"
-pkg_shasum="ba63a6638fb181c6a7f24d8efb5f5750a648d85fa9456a4a3a9be71471f098f1"
+_version="1.6.1108"
+pkg_shasum="5145d59c2ec86290c8c5329171ece2b1289e795a3524c3db97b533679dc668b9"
 
 pkg_name="hab"
 pkg_origin="core"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_source="https://github.com/habitat-sh/habitat/archive/${commit_hash}.tar.gz"
-pkg_dirname="habitat-${commit_hash}"
+pkg_source="https://github.com/habitat-sh/habitat/archive/refs/tags/${_version}.tar.gz"
+pkg_dirname="habitat-${_version}"
 
 # The result is a portable, static binary in a zero-dependency package.
 pkg_deps=()


### PR DESCRIPTION
The `core/build-tools-hab*` and `core/hab*` packages were pinned to a commit pointing to the 1.6.639 tag (commit hash: 21914065e338e2ce9fb4880b92326abfa79737aa). The build with this commit is failing because it uses an unused dependency that has been removed from the source. 

This PR updates the hab* packages to the 1.6.1108 tag, which includes a fix for build failures.

Also update hab-cc-wrapper and hab-ld-waraper to use pkg_source with tags and remove commit_hash