### PR TITLE
[Package Monitor] Bumps patch versions

### DIFF
--- a/packages/applications/databases/memcached/plan.sh
+++ b/packages/applications/databases/memcached/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=memcached
 pkg_origin=core
-pkg_version=1.6.18
+pkg_version="1.6.29"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="Distributed memory object caching system"
 pkg_upstream_url=https://memcached.org/
 pkg_license=('BSD-3-Clause')
 pkg_source="http://www.memcached.org/files/${pkg_name}-${pkg_version}.tar.gz"
-pkg_shasum=cbdd6ab8810649ac5d92fcd0fcb0ca931d8a9dbd0ad8cc575b47222eedd64158
+pkg_shasum=269643d518b7ba2033c7a1f66fdfc560d72725a2822194d90c8235408c443a49
 pkg_deps=(
 	core/glibc
 	core/cyrus-sasl

--- a/packages/applications/databases/minio/.hab-plan-config.toml
+++ b/packages/applications/databases/minio/.hab-plan-config.toml
@@ -1,3 +1,3 @@
 [rules]
-license-not-found = {level = "off", source-shasum = "0ca0015e8ed4392190c04e21391e9fdcbdbdc5b85622608f120c8e31aa7bdfa5"}
-missing-license = {level = "off", source-shasum = "0ca0015e8ed4392190c04e21391e9fdcbdbdc5b85622608f120c8e31aa7bdfa5"}
+license-not-found = {level = "off", source-shasum = "2ede605a84e658993e6868b5a1ab0cee493906901e9cc150153adbf0913fcfcc"}
+missing-license = {level = "off", source-shasum = "2ede605a84e658993e6868b5a1ab0cee493906901e9cc150153adbf0913fcfcc"}

--- a/packages/applications/databases/minio/plan.sh
+++ b/packages/applications/databases/minio/plan.sh
@@ -1,10 +1,10 @@
 pkg_name="minio"
 pkg_origin="core"
-pkg_version="2023-01-02T09-40-09Z"
+pkg_version="2023-01-31T02-24-19Z"
 pkg_description="Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure."
 pkg_upstream_url="https://minio.io"
 pkg_source="https://dl.minio.io/server/minio/release/linux-arm64/archive/minio.RELEASE.${pkg_version}"
-pkg_shasum="0ca0015e8ed4392190c04e21391e9fdcbdbdc5b85622608f120c8e31aa7bdfa5"
+pkg_shasum="2ede605a84e658993e6868b5a1ab0cee493906901e9cc150153adbf0913fcfcc"
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
## Updates
- Bumps [memcached](https://memcached.org/) from 1.6.18 to 1.6.29.
- Bumps [minio](https://minio.io) from 2023-01-02T09-40-09Z to 2023-01-31T02-24-19Z.
