### PR TITLE
Haskell toolchain for linux

### DIFF
--- a/packages/bootstrap/stage1/ghc/.hab-plan-config.toml
+++ b/packages/bootstrap/stage1/ghc/.hab-plan-config.toml
@@ -1,0 +1,5 @@
+[rules]
+license-not-found = {level = "off", source-shasum = "c4c0124857265926f1cf22a09d950d7ba989ff94053a4ddf3dcdab5359f4cab7"}
+duplicate-runtime-binary = {level = "off"}
+unused-runpath-entry = {level = "off"}
+unused-dependency = { level = "off" }

--- a/packages/bootstrap/stage1/ghc/plan.sh
+++ b/packages/bootstrap/stage1/ghc/plan.sh
@@ -1,0 +1,67 @@
+pkg_name=ghc-stage1
+pkg_origin=core
+pkg_version=9.6.3
+pkg_license=('BSD-3-Clause')
+pkg_upstream_url="https://www.haskell.org/ghc/"
+pkg_description="The Glasgow Haskell Compiler - Binary Bootstrap"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="http://downloads.haskell.org/~ghc/${pkg_version}/ghc-${pkg_version}-x86_64-deb11-linux.tar.xz"
+pkg_shasum="c4c0124857265926f1cf22a09d950d7ba989ff94053a4ddf3dcdab5359f4cab7"
+pkg_dirname="ghc-${pkg_version}"
+
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_interpreters=(bin/runhaskell bin/runghc)
+
+pkg_deps=(
+  core/glibc
+  core/gmp
+  core/libffi
+  core/ncurses
+)
+
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/build-tools-patchelf
+)
+
+do_unpack() {
+  do_default_unpack
+
+  mv ghc-${pkg_version}-x86_64-unknown-linux ${pkg_dirname}
+}
+
+do_build() {
+  ./configure \
+    --prefix="${pkg_prefix}"
+}
+
+do_install() {
+  # make install
+  cp -r bin include lib wrappers "${pkg_prefix}"
+
+  # The ghc binary (ghc-${pkg_version}) requires libtinfo.so.6, which is not available
+  # in the current ncurses build because it was built with the --enable-widec option.
+  ln -sfv "$(pkg_path_for ncurses)/lib/libtinfow.so" "${pkg_prefix}/lib/x86_64-linux-ghc-${pkg_version}/libtinfo.so.6"
+
+  # export LD_RUN_PATH="${LD_RUN_PATH}:${pkg_prefix}/lib"
+  export LD_RUN_PATH="${LD_RUN_PATH}:${pkg_prefix}/lib/x86_64-linux-ghc-${pkg_version}"
+
+  build_line "Setting rpath for all binaries to '${LD_RUN_PATH}'"
+  find "${pkg_prefix}/bin" "${pkg_prefix}/lib/bin" -type f -executable \
+    -exec patchelf --set-interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" \
+    --set-rpath "${LD_RUN_PATH}" {} \;
+
+  build_line "Setting rpath for all libraries to '${LD_RUN_PATH}'"
+  find "${pkg_prefix}/lib" -type f -name "*.so" \
+    -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
+
+    patchelf --set-rpath "$LD_RUN_PATH" ${pkg_prefix}/lib/x86_64-linux-ghc-${pkg_version}/libffi.so.8.1.2
+    patchelf --set-rpath "$LD_RUN_PATH" ${pkg_prefix}/lib/x86_64-linux-ghc-${pkg_version}/libffi.so.8
+}
+
+ do_strip() {
+   return 0
+ }

--- a/packages/bootstrap/stage1/ghc/plan.sh
+++ b/packages/bootstrap/stage1/ghc/plan.sh
@@ -22,7 +22,7 @@ pkg_deps=(
 )
 
 pkg_build_deps=(
-  core/gcc
+  core/gcc-base
   core/make
   core/build-tools-patchelf
 )
@@ -34,12 +34,16 @@ do_unpack() {
 }
 
 do_build() {
+   export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}":"$(pkg_path_for gmp)/lib"
   ./configure \
-    --prefix="${pkg_prefix}"
+    --prefix="${pkg_prefix}" \
+    CC="$(pkg_path_for gcc-base)/bin/gcc" \
+    CXX="$(pkg_path_for gcc-base)/bin/g++" \
+    --disable-ld-override
 }
 
 do_install() {
-  # make install
+  make lib/settings
   cp -r bin include lib wrappers "${pkg_prefix}"
 
   # The ghc binary (ghc-${pkg_version}) requires libtinfo.so.6, which is not available

--- a/packages/development/haskell-modules/alex/plan.sh
+++ b/packages/development/haskell-modules/alex/plan.sh
@@ -1,0 +1,45 @@
+pkg_name=alex
+pkg_origin=core
+pkg_version="3.5.1.0"
+pkg_license=("BSD-3-Clause")
+pkg_upstream_url=http://www.haskell.org/alex/
+pkg_description="Alex is a tool for generating lexical analysers in Haskell. It takes a description of tokens based on regular expressions and generates a Haskell module containing code for scanning text efficiently. It is similar to the tool lex or flex for C/C++."
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://hackage.haskell.org/package/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07"
+
+pkg_deps=(
+	core/glibc
+	core/gmp
+	#core/libffi
+)
+pkg_build_deps=(
+	core/gcc-base
+	core/cabal-install
+	core/ghc-stage1
+	core/make
+)
+
+pkg_bin_dirs=(bin)
+
+do_clean() {
+	do_default_clean
+
+	# Strip any previous cabal config/cache
+	rm -rf /root/.cabal
+}
+
+do_build() {
+	export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pkg_path_for gmp)/lib
+	cabal v2-update
+	cabal v2-configure --prefix=${pkg_prefix} -w "$(pkg_path_for ghc-stage1)/bin/ghc" --disable-documentation
+	cabal v2-build -v --extra-lib-dirs="$(pkg_path_for gmp)/lib" --extra-include-dirs="$(pkg_path_for gmp)/include"
+}
+
+do_install() {
+	cabal v2-install --installdir="${pkg_prefix}/bin" --install-method=copy --extra-include-dirs="$(pkg_path_for gmp)/include" --extra-lib-dirs="$(pkg_path_for gmp)/lib"
+}
+
+do_check() {
+	cabal v2-test
+}

--- a/packages/development/haskell-modules/cabal-install/plan.sh
+++ b/packages/development/haskell-modules/cabal-install/plan.sh
@@ -1,0 +1,47 @@
+pkg_name="cabal-install"
+pkg_origin=core
+pkg_version="3.12.1.0"
+pkg_license=('')
+pkg_upstream_url="https://www.haskell.org/cabal/"
+pkg_description="Command-line interface for Cabal and Hackage"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://downloads.haskell.org/~cabal/cabal-install-${pkg_version}/cabal-install-${pkg_version}-x86_64-linux-deb11.tar.xz"
+pkg_shasum="4f60cf1c72f4ad4d82d668839ac61ae15ae4faf6c4b809395799e8a3ee622051"
+
+pkg_deps=(
+	core/glibc
+	core/zlib
+	core/gmp
+)
+
+pkg_build_deps=(
+	core/build-tools-patchelf
+)
+
+pkg_bin_dirs=(bin)
+
+do_clean() {
+	do_default_clean
+
+	# Strip any previous cabal config
+	rm -rf /root/.cabal
+}
+
+do_build() {
+	return 0
+}
+
+do_install() {
+	cp ${HAB_CACHE_SRC_PATH}/cabal ${pkg_prefix}/bin
+	cp ${HAB_CACHE_SRC_PATH}/plan.json ${pkg_prefix}/bin
+
+	LD_RUN_PATH=${LD_RUN_PATH}:$(pkg_path_for glibc)/lib:$(pkg_path_for gmp)/lib:$(pkg_path_for zlib)/lib
+
+	build_line "Setting rpath for all binaries to '${LD_RUN_PATH}'"
+	patchelf --set-rpath "${LD_RUN_PATH}" ${pkg_prefix}/bin/cabal
+	patchelf --set-interpreter $(pkg_path_for glibc)/lib64/ld-linux-x86-64.so.2 ${pkg_prefix}/bin/cabal
+}
+
+do_strip() {
+	return 0
+}

--- a/packages/development/haskell-modules/happy/plan.sh
+++ b/packages/development/haskell-modules/happy/plan.sh
@@ -1,0 +1,49 @@
+pkg_name=happy
+pkg_origin=core
+pkg_version="1.20.1.1"
+pkg_license=('BSD-2-Clause')
+pkg_upstream_url="https://www.haskell.org/happy/"
+pkg_description="Happy is a parser generator for Haskell. Given a grammar specification in BNF, Happy generates Haskell code to parse the grammar. Happy works in a similar way to the yacc tool for C."
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://hackage.haskell.org/package/${pkg_name}-${pkg_version}/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="8b4e7dc5a6c5fd666f8f7163232931ab28746d0d17da8fa1cbd68be9e878881b"
+
+pkg_deps=(
+	core/glibc
+	core/gmp
+	# core/libffi
+)
+pkg_build_deps=(
+	core/gcc-base
+	core/cabal-install
+	core/ghc-stage1
+	core/make
+)
+
+pkg_bin_dirs=(bin)
+
+do_clean() {
+	do_default_clean
+
+	# Strip any previous cabal config/cache
+	rm -rf /root/.cabal
+}
+
+do_prepare() {
+	# Set locale
+	export LANG="en_US.utf8"
+}
+
+do_build() {
+	cabal v2-update
+	cabal v2-configure --prefix=${pkg_prefix} -w "$(pkg_path_for ghc-stage1)/bin/ghc" --disable-documentation
+	cabal v2-build -v --extra-lib-dirs="$(pkg_path_for gmp)/lib" --extra-include-dirs="$(pkg_path_for gmp)/include"
+}
+
+do_install() {
+	cabal install --installdir="${pkg_prefix}/bin" --install-method=copy --extra-include-dirs="$(pkg_path_for gmp)/include" --extra-lib-dirs="$(pkg_path_for gmp)/lib"
+}
+
+do_check() {
+	cabal v2-test
+}


### PR DESCRIPTION
This PR adds the ghc-stage1 package for the x86_64 platform. The GHC package requires libtinfo.so.6, which is typically provided by the ncurses package. However, since ncurses was built with the --enable-widec option, there is no libtinfo.so.6 library (or symbolic link) available by default. To address this, a workaround has been implemented by creating a symlink. Ideally, this issue should be fixed in the ncurses package itself.

```
/hab/pkgs/core/ghc-stage1/9.6.3/20240827113323/bin/ghc --version
/hab/pkgs/core/ghc-stage1/9.6.3/20240827113323/bin/ghc: /hab/pkgs/core/ghc-stage1/9.6.3/20240827113323/lib/x86_64-linux-ghc-9.6.3/libtinfo.so.6: no version information available (required by /hab/pkgs/core/ghc-stage1/9.6.3/20240827113323/lib/x86_64-linux-ghc-9.6.3/libHShaskeline-0.8.2.1-ghc9.6.3.so)
/hab/pkgs/core/ghc-stage1/9.6.3/20240827113323/bin/ghc: /hab/pkgs/core/ghc-stage1/9.6.3/20240827113323/lib/x86_64-linux-ghc-9.6.3/libtinfo.so.6: no version information available (required by /hab/pkgs/core/ghc-stage1/9.6.3/20240827113323/lib/x86_64-linux-ghc-9.6.3/libHSterminfo-0.4.1.6-ghc9.6.3.so)
The Glorious Glasgow Haskell Compilation System, version 9.6.3
```

We need to investigate the issue reported above to ensure this package is compatible with building the standard `core/ghc` package before proceeding further.