### PR TITLE
add pester build function

### DIFF
--- a/packages/development/tools/misc/pester/README.md
+++ b/packages/development/tools/misc/pester/README.md
@@ -1,0 +1,24 @@
+# pester
+
+Pester is the ubiquitous test and mock framework for PowerShell.
+
+## Maintainers
+
+The Habitat Maintainers humans@habitat.sh
+
+## Type of Package
+
+A Binary package containing a Powershell Module
+
+## Usage
+
+Import the pester module:
+
+```
+# From a powershell prompt
+Import-Module "$(hab pkg path core/pester)\module\Pester.psd1"
+# From a plan.ps1
+Import-Module "$(Get-HabPackagePath pester)\module\Pester.psd1"
+```
+
+Now you can call pester functions like `Invoke-Pester`.

--- a/packages/development/tools/misc/pester/plan.ps1
+++ b/packages/development/tools/misc/pester/plan.ps1
@@ -14,5 +14,5 @@ function Invoke-Build {
 	.\build.ps1 -Clean
 }
 function Invoke-Install {
-    Copy-Item "pester-$pkg_version\*" "$pkg_prefix/module" -Recurse -Force
+    Copy-Item "pester-$pkg_version\bin\*" "$pkg_prefix/module" -Recurse -Force
 }

--- a/packages/development/tools/misc/pester/plan.ps1
+++ b/packages/development/tools/misc/pester/plan.ps1
@@ -8,7 +8,11 @@ $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_source="https://github.com/pester/Pester/archive/$pkg_version.zip"
 $pkg_shasum="39dac4c4c19ad2ffce1e863bea8b68b05a648156833933ecde1826a49ac8f2d6"
 $pkg_bin_dirs=@("module/bin")
-
+$pkg_build_deps=@("core/dotnet-core-sdk")
+function Invoke-Build {
+	Set-Location "$pkg_name-$pkg_version"
+	.\build.ps1 -Clean
+}
 function Invoke-Install {
     Copy-Item "pester-$pkg_version\*" "$pkg_prefix/module" -Recurse -Force
 }


### PR DESCRIPTION
Previous versions were shipping binary.
Latest versions needs to be built with dotnet.
Added build function for pester.