### PR TITLE
fix for openssl load error with ruby >3.1

### DIFF
--- a/packages/development/interpreters/ruby/3_4/plan.sh
+++ b/packages/development/interpreters/ruby/3_4/plan.sh
@@ -52,6 +52,8 @@ do_build() {
 		--disable-install-doc \
 		--with-openssl-dir="$(pkg_path_for core/openssl)" \
 		--with-libyaml-dir="$(pkg_path_for core/libyaml)" \
+		--with-openssl-lib="$(pkg_path_for core/openssl)/lib64" \
+		--with-openssl-include="$(pkg_path_for core/openssl)/include" \
 		--with-baseruby="$(pkg_path_for core/ruby3_1)/bin/ruby"
 
 	make -j"$(nproc)"


### PR DESCRIPTION
fix for openssl load error with ruby >3.1
ref: chef-15323