### PR TITLE
Adding openssl lib path updates

### DIFF
--- a/packages/development/interpreters/ruby/3_1/plan.sh
+++ b/packages/development/interpreters/ruby/3_1/plan.sh
@@ -52,6 +52,8 @@ do_build() {
 		--disable-install-doc \
 		--with-openssl-dir="$(pkg_path_for core/openssl)" \
 		--with-libyaml-dir="$(pkg_path_for core/libyaml)" \
+        --with-openssl-lib="$(pkg_path_for core/openssl)/lib64" \
+        --with-openssl-include="$(pkg_path_for core/openssl)/include" \
 		--without-baseruby
 
 	make -j"$(nproc)"


### PR DESCRIPTION
Updating the lib and include paths. Ruby is looking in /lib for the openssl files and that breaks the build