### PR TITLE
fix buildah runtime errors creating image

### DIFF
--- a/packages/development/tools/buildah/.hab-plan-config.toml
+++ b/packages/development/tools/buildah/.hab-plan-config.toml
@@ -1,3 +1,4 @@
 [rules]
 unused-runpath-entry = {ignored_files = ["bin/*"]}
-unused-dependency = {ignored_packages = ["core/{libassuan,libgpg-error}"]}
+# core/runc and core/netavark are required for habitat container exporter. Added by Matt Wrock
+unused-dependency = {ignored_packages = ["core/{libassuan,libgpg-error,runc,netavark}"]}

--- a/packages/development/tools/buildah/plan.sh
+++ b/packages/development/tools/buildah/plan.sh
@@ -8,6 +8,8 @@ pkg_deps=(
     core/libassuan
     core/libgpg-error
     core/libseccomp
+    core/netavark
+    core/runc
 )
 pkg_build_deps=(
     core/bzip2
@@ -30,6 +32,10 @@ do_download() {
         --single-branch \
         "${pkg_upstream_url}" \
         "${repo_path}"
+}
+
+do_setup_environment() {
+  set_runtime_env CONTAINERS_HELPER_BINARY_DIR "$(pkg_path_for core/netavark)/bin"
 }
 
 do_prepare() {

--- a/packages/development/tools/netavark/plan.sh
+++ b/packages/development/tools/netavark/plan.sh
@@ -1,0 +1,31 @@
+pkg_name=netavark
+pkg_origin=core
+pkg_version="1.12.2"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_deps=(
+  core/glibc
+  core/gcc-base
+)
+pkg_build_deps=(
+    core/protobuf
+    core/rust
+)
+pkg_bin_dirs=(bin)
+pkg_description="A rust based network stack for containers"
+pkg_upstream_url="https://github.com/containers/netavark"
+pkg_source="https://github.com/containers/netavark/archive/v${pkg_version}.tar.gz"
+pkg_shasum=d1e5a7e65b825724fd084b0162084d9b61db8cda1dad26de8a07be1bd6891dbc
+
+do_prepare() {
+    export PROTOC="$(pkg_path_for protobuf)/bin/protoc"
+}
+
+do_build() {
+	cargo build --release
+}
+
+do_install() {
+    install -v -D "${CACHE_PATH}/target/release/netavark" "${pkg_prefix}/bin/netavark"
+}
+


### PR DESCRIPTION
This fixes `hab pkg export container --engine buildah` when built against LTS-2024.