### PR TITLE
Fix pkg_source for visual-build-tools-2022

### DIFF
--- a/packages/tools/admin/visual-build-tools-2022/plan.ps1
+++ b/packages/tools/admin/visual-build-tools-2022/plan.ps1
@@ -5,8 +5,13 @@ $pkg_description="Standalone compiler, libraries and scripts"
 $pkg_upstream_url="https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022"
 $pkg_license=@("Microsoft Software License")
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_source="https://aka.ms/vs/17/release/vs_BuildTools.exe"
-$pkg_shasum="7d9ec4afc0346130be7244673bb60ab159eb99794e1e5101d4dc973047c5eeee"
+# When accessing the vs_BuildTools.exe from https://aka.ms/vs/17/release/vs_BuildTools.exe, 
+# it always provides the latest version of the build tools, which, in turn, can change dependencies. 
+# This may cause issues due to differences in the build time and result in a loss of reproducibility. 
+# Instead, we should always use the exact version of the build tools based on the configured version.
+# https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/Microsoft/VisualStudio/2022/BuildTools
+$pkg_source="https://download.visualstudio.microsoft.com/download/pr/7593f7f0-1b5b-43e1-b0a4-cceb004343ca/9a5b493178cde0ec0aa3543d3285c3e037956119ca426aaed14f59d24fe62e90/vs_BuildTools.exe"
+$pkg_shasum="9a5b493178cde0ec0aa3543d3285c3e037956119ca426aaed14f59d24fe62e90"
 $pkg_build_deps=@("core/7zip")
 
 $pkg_bin_dirs=@(


### PR DESCRIPTION
When accessing the `vs_BuildTools.exe` from https://aka.ms/vs/17/release/vs_BuildTools.exe while building the `visual-build-tools-2022` package, it always provides the latest version of the build tools. This, in turn, can lead to changes in dependencies, potentially causing issues due to differences in build time and resulting in a loss of reproducibility.

Additionally, this issue arises when `hab-auto-build` is extended to support Windows. To avoid these problems, it is crucial to use the exact version of the build tools based on the configured version.

Here’s how you can identify the correct version to use:

- Navigate to the [winget-pkgs repository](https://github.com/microsoft/winget-pkgs/tree/master/manifests/m/Microsoft/VisualStudio/2022/BuildTools).
- Select the desired version (e.g., 17.10.4).
- In the corresponding /Microsoft.VisualStudio.2022.BuildTools.installer.yaml file, locate the InstallerUrl and InstallerSha256 properties.

Using these properties ensures you reference the exact version required for consistent and reproducible builds.

Additional Refs:
https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history
